### PR TITLE
fixing glide requirement in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ lint: deps-lint
 	--vendor
 
 deps:
+	go get github.com/Masterminds/glide
 	glide install
 
 deps-lint: deps


### PR DESCRIPTION
I have problem in general build proccess. My steps:
```
$ mkdir akubra
$ cd akubra
$ export GOPATH=`pwd`\ && export PATH=$PATH:$GOPATH/bin
~akubra $ go get github.com/allegro/akubra
~akubra $ make
glide install
make: glide: Command not found
make: *** [deps] Error 127
```

