### PR TITLE
Akubra config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ the pool and error is logged.
 Configuration is read from a YAML configuration file with the following fields:
 
 ```yaml
-# Listen interface and port e.g. "0:8000", "localhost:9090", ":80"
+# Listen interface and port e.g. "127.0.0.1:9090", ":80"
 Listen: ":8080"
 # Additional not AWS S3 specific headers proxy will add to original request
 AdditionalResponseHeaders:

--- a/config/config.go
+++ b/config/config.go
@@ -62,13 +62,13 @@ type YamlConfig struct {
 	MaxIdleConns int `yaml:"MaxIdleConns" validate:"min=0"`
 	// MaxIdleConnsPerHost see: https://golang.org/pkg/net/http/#Transport
 	// Default 100
-	MaxIdleConnsPerHost int `yaml:"MaxIdleConnsPerHost" validate:"min=1"`
+	MaxIdleConnsPerHost int `yaml:"MaxIdleConnsPerHost" validate:"min=0"`
 	// IdleConnTimeout see: https://golang.org/pkg/net/http/#Transport
 	// Default 0 (no limit)
-	IdleConnTimeout metrics.Interval `yaml:"IdleConnTimeout" validate:"regexp=^([1-9][0-9]*s)$"`
+	IdleConnTimeout metrics.Interval `yaml:"IdleConnTimeout"`
 	// ResponseHeaderTimeout see: https://golang.org/pkg/net/http/#Transport
 	// Default 5s (no limit)
-	ResponseHeaderTimeout metrics.Interval `yaml:"ResponseHeaderTimeout" validate:"regexp=^([1-9][0-9]*s)$"`
+	ResponseHeaderTimeout metrics.Interval `yaml:"ResponseHeaderTimeout"`
 
 	Clusters map[string]ClusterConfig `yaml:"Clusters,omitempty"`
 	// Additional not amazon specific headers proxy will add to original request
@@ -147,10 +147,10 @@ func (j *AdditionalHeaders) UnmarshalYAML(unmarshal func(interface{}) error) err
 
 	for key, value := range headers {
 		if strings.TrimSpace(key) == "" {
-			return fmt.Errorf("Empty additional header key: %q with value: %q", key, value)
+			return fmt.Errorf("Empty additional header with value: %q", value)
 		}
 		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("Empty additional header value: %q with key: %q", value, key)
+			return fmt.Errorf("Empty additional header with key: %q", key)
 		}
 	}
 	return nil
@@ -244,7 +244,7 @@ func setupSyncLogThread(conf *Config, methods []interface{}) {
 	if len(conf.SyncLogMethods) > 0 {
 		conf.SyncLogMethodsSet = set.NewThreadUnsafeSet()
 		for _, v := range conf.SyncLogMethods {
-			conf.SyncLogMethodsSet.Add(v)
+			conf.SyncLogMethodsSet.Add(v.method)
 		}
 	} else {
 		conf.SyncLogMethodsSet = set.NewThreadUnsafeSetFromSlice(methods)

--- a/config/config.go
+++ b/config/config.go
@@ -160,10 +160,13 @@ func setupSyncLogThread(conf *Config, methods []interface{}) {
 }
 
 // ValidateConf validate configuration from YAML file
-func ValidateConf(conf YamlConfig) (bool, map[string][]error) {
+func ValidateConf(conf YamlConfig, enableLogicalValidator bool) (bool, map[string][]error) {
 	validator.SetValidationFunc("NoEmptyValuesSlice", NoEmptyValuesInSliceValidator)
 	validator.SetValidationFunc("UniqueValuesSlice", UniqueValuesInSliceValidator)
 	valid, validationErrors := validator.Validate(conf)
+	if enableLogicalValidator {
+		conf.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
+	}
 	for propertyName, validatorMessage := range validationErrors {
 		log.Printf("[ ERROR ] YAML config validation -> propertyName: '%s', validatorMessage: '%s'\n", propertyName, validatorMessage)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type YamlConfig struct {
 	// List of backend URI's e.g. "http://s3.mydatacenter.org"
 	Backends []shardingconfig.YAMLUrl `yaml:"Backends,omitempty,flow"`
 	// Maximum accepted body size
-	BodyMaxSize string `yaml:"BodyMaxSize,omitempty" validate:"regexp=^([1-9][0-9]+[kMG][B])$"`
+	BodyMaxSize shardingconfig.HumanSizeUnits `yaml:"BodyMaxSize,omitempty"`
 	// MaxIdleConns see: https://golang.org/pkg/net/http/#Transport
 	// Default 0 (no limit)
 	MaxIdleConns int `yaml:"MaxIdleConns" validate:"min=0"`

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-
 // ClusterConfig defines cluster configuration
 type ClusterConfig struct {
 	// Backends should contain s3 backend urls
@@ -51,11 +50,11 @@ type ADDITIONALHEADERS struct {
 // YamlConfig contains configuration fields of config file
 type YamlConfig struct {
 	// Listen interface and port e.g. "0.0.0.0:8000", "127.0.0.1:9090", ":80"
-	Listen string 				`yaml:"Listen,omitempty" validate:"regexp=^([0-9]+[.][0-9]+[.][0-9]+[.][0-9])?[:][0-9]\{1,6\})$"`
+	Listen string 				`yaml:"Listen,omitempty" validate:"regexp=^(([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)?[:][0-9]+)$"`
 	// List of backend URI's e.g. "http://s3.mydatacenter.org"
 	Backends []YAMLURL 			`yaml:"Backends,omitempty,flow"`
 	// Maximum accepted body size
-	BodyMaxSize string 			`yaml:"BodyMaxSize,omitempty" validate:"regexp=^([1-9][0-9]+[mkgMKG][Bb])$"`
+	BodyMaxSize string 			`yaml:"BodyMaxSize,omitempty" validate:"regexp=^([1-9][0-9]+[kMG][B])$"`
 	// MaxIdleConns see: https://golang.org/pkg/net/http/#Transport
 	// Default 0 (no limit)
 	MaxIdleConns int 			`yaml:"MaxIdleConns" validate:"min=0"`
@@ -71,9 +70,9 @@ type YamlConfig struct {
 
 	Clusters map[string]ClusterConfig 	`yaml:"Clusters,omitempty"`
 	// Additional not amazon specific headers proxy will add to original request
-	AdditionalRequestHeaders map[string]string /* ADDITIONALHEADERS */ `yaml:"AdditionalRequestHeaders,omitempty"`
+	AdditionalRequestHeaders map[string]string /* ADDITIONALHEADERS */ `yaml:"AdditionalRequestHeaders,omitempty,flow"`
 	// Additional headers added to backend response
-	AdditionalResponseHeaders map[string]string /* ADDITIONALHEADERS */ `yaml:"AdditionalResponseHeaders,omitempty"`
+	AdditionalResponseHeaders map[string]string /* ADDITIONALHEADERS */ `yaml:"AdditionalResponseHeaders,omitempty,flow"`
 	// Read timeout on outgoing connections
 
 	// Backend in maintenance mode. Akubra will not send data there

--- a/config/config.go
+++ b/config/config.go
@@ -1,16 +1,17 @@
 package config
 
 import (
-	logconfig "github.com/allegro/akubra/log/config"
-	set "github.com/deckarep/golang-set"
-	"github.com/go-validator/validator"
-	yaml "gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
-	shardingconfig "github.com/allegro/akubra/sharding/config"
-	"github.com/allegro/akubra/metrics"
+
 	"github.com/allegro/akubra/log"
+	logconfig "github.com/allegro/akubra/log/config"
+	"github.com/allegro/akubra/metrics"
+	shardingconfig "github.com/allegro/akubra/sharding/config"
+	set "github.com/deckarep/golang-set"
+	"github.com/go-validator/validator"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // YamlConfig contains configuration fields of config file
@@ -48,7 +49,7 @@ type YamlConfig struct {
 	SyncLogMethods []shardingconfig.SyncLogMethod `yaml:"SyncLogMethods,omitempty"`
 	Client         *shardingconfig.ClientConfig   `yaml:"Client,omitempty"`
 	Logging        logconfig.LoggingConfig        `yaml:"Logging,omitempty"`
-	Metrics        metrics.Config           `yaml:"Metrics,omitempty"`
+	Metrics        metrics.Config                 `yaml:"Metrics,omitempty"`
 	// Should we keep alive connections with backend servers
 	DisableKeepAlives bool `yaml:"DisableKeepAlives"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,14 +1,15 @@
 package config
 
 import (
+	"net/url"
+	"testing"
+	"time"
+
 	logconfig "github.com/allegro/akubra/log/config"
 	"github.com/allegro/akubra/metrics"
 	shardingconfig "github.com/allegro/akubra/sharding/config"
 	"github.com/go-yaml/yaml"
 	"github.com/stretchr/testify/assert"
-	"net/url"
-	"testing"
-	"time"
 )
 
 type TestYaml struct {
@@ -240,7 +241,7 @@ func prepareYamlConfig(bodyMaxSize string, idleConnTimeoutInp time.Duration, res
 	maintainedBackendHost string, listen string, clientCfgName string,
 	clientClusters []string) YamlConfig {
 
-	syncLogMethods := []shardingconfig.SyncLogMethod{{Method:"POST"}}
+	syncLogMethods := []shardingconfig.SyncLogMethod{{Method: "POST"}}
 
 	url1 := url.URL{
 		Scheme: "http",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,7 @@ type YamlConfigTest struct {
 func (t *YamlConfigTest) NewYamlConfigTest() *YamlConfig {
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	t.YamlConfig = prepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{"dev"})
+	t.YamlConfig = PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{"cluster1test"})
 	return &t.YamlConfig
 }
 
@@ -65,7 +65,7 @@ func TestShouldValidateListenConf(t *testing.T) {
 
 	for _, listenValue := range testListenData {
 		testConf.NewYamlConfigTest().Listen = listenValue
-		result, _ := ValidateConf(testConf.YamlConfig)
+		result, _ := ValidateConf(testConf.YamlConfig, false)
 		assert.True(t, result, "Should be true")
 	}
 }
@@ -75,7 +75,7 @@ func TestShouldNotValidateListenConf(t *testing.T) {
 
 	for _, listenWrongValue := range testWrongListenData {
 		testConf.NewYamlConfigTest().Listen = listenWrongValue
-		result, _ := ValidateConf(testConf.YamlConfig)
+		result, _ := ValidateConf(testConf.YamlConfig, false)
 		assert.False(t, result, "Should be false")
 	}
 }
@@ -84,9 +84,9 @@ func TestShouldValidateConfMaintainedBackendWhenNotEmpty(t *testing.T) {
 	maintainedBackendHost := "127.0.0.1:85"
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	testConfData := prepareYamlConfig(size, 21, 32, maintainedBackendHost, ":80", "client1", []string{"dev"})
+	testConfData := PrepareYamlConfig(size, 21, 32, maintainedBackendHost, ":80", "client1", []string{"cluster1test"})
 
-	result, _ := ValidateConf(testConfData)
+	result, _ := ValidateConf(testConfData, false)
 
 	assert.True(t, result, "Should be true")
 }
@@ -95,9 +95,9 @@ func TestShouldValidateConfMaintainedBackendWhenEmpty(t *testing.T) {
 	maintainedBackendHost := ""
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 4096
-	testConfData := prepareYamlConfig(size, 22, 33, maintainedBackendHost, ":80", "client1", []string{"dev"})
+	testConfData := PrepareYamlConfig(size, 22, 33, maintainedBackendHost, ":80", "client1", []string{"cluster1test"})
 
-	result, _ := ValidateConf(testConfData)
+	result, _ := ValidateConf(testConfData, false)
 
 	assert.True(t, result, "Should be true")
 }
@@ -106,7 +106,7 @@ func TestShouldValidateConfClientNameWithMinLenght(t *testing.T) {
 	var testConf YamlConfigTest
 	testConf.NewYamlConfigTest().Client.Name = "c"
 
-	result, _ := ValidateConf(testConf.YamlConfig)
+	result, _ := ValidateConf(testConf.YamlConfig, false)
 
 	assert.True(t, result, "Should be true")
 }
@@ -115,7 +115,7 @@ func TestShouldNotValidateConfClientNameWhenEmpty(t *testing.T) {
 	var testConf YamlConfigTest
 	testConf.NewYamlConfigTest().Client.Name = ""
 
-	result, _ := ValidateConf(testConf.YamlConfig)
+	result, _ := ValidateConf(testConf.YamlConfig, false)
 
 	assert.False(t, result, "Should be false")
 }
@@ -124,7 +124,7 @@ func TestShouldValidateConfClientClustersValues(t *testing.T) {
 	var testConf YamlConfigTest
 	testConf.NewYamlConfigTest().Client.Clusters = []string{"prod", "jprod"}
 
-	result, _ := ValidateConf(testConf.YamlConfig)
+	result, _ := ValidateConf(testConf.YamlConfig, false)
 
 	assert.True(t, result, "Should be true")
 }
@@ -133,7 +133,7 @@ func TestShouldNotValidateConfClientClustersValuesWhenEmpty(t *testing.T) {
 	var testConf YamlConfigTest
 	testConf.NewYamlConfigTest().Client.Clusters = []string{"prod", "  "}
 
-	result, validationErrors := ValidateConf(testConf.YamlConfig)
+	result, validationErrors := ValidateConf(testConf.YamlConfig, false)
 
 	assert.Contains(t, validationErrors, "Client.Clusters")
 	assert.False(t, result, "Should be false")
@@ -143,7 +143,7 @@ func TestShouldNotValidateConfClientClustersValuesWhenDuplicated(t *testing.T) {
 	var testConf YamlConfigTest
 	testConf.NewYamlConfigTest().Client.Clusters = []string{"jprod", "jprod"}
 
-	result, validationErrors := ValidateConf(testConf.YamlConfig)
+	result, validationErrors := ValidateConf(testConf.YamlConfig, false)
 
 	assert.Contains(t, validationErrors, "Client.Clusters")
 	assert.False(t, result, "Should be false")
@@ -247,7 +247,7 @@ func TestShouldNotValidateBodyMaxSizeWithZero(t *testing.T) {
 	assert.Error(t, err, "Missing BodyMaxSize should return error")
 }
 
-func prepareYamlConfig(bodyMaxSize shardingconfig.HumanSizeUnits, idleConnTimeoutInp time.Duration, responseHeaderTimeoutInp time.Duration,
+func PrepareYamlConfig(bodyMaxSize shardingconfig.HumanSizeUnits, idleConnTimeoutInp time.Duration, responseHeaderTimeoutInp time.Duration,
 	maintainedBackendHost string, listen string, clientCfgName string,
 	clientClusters []string) YamlConfig {
 
@@ -261,7 +261,7 @@ func prepareYamlConfig(bodyMaxSize shardingconfig.HumanSizeUnits, idleConnTimeou
 
 	maxIdleConns := 1
 	maxIdleConnsPerHost := 2
-	clusters := map[string]shardingconfig.ClusterConfig{"test": {
+	clusters := map[string]shardingconfig.ClusterConfig{"cluster1test": {
 		yamlURL,
 		"replicator",
 		1,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,7 +49,7 @@ func TestShouldValidateListenConf(t *testing.T) {
 	testListenData := []string{"127.0.0.1:8080", ":8080", ":80"}
 
 	for _, listenValue := range testListenData {
-		testConfData := prepareYamlConfig("100MB", 31, 45, "127.0.0.1:81", listenValue, nil, "client1", []string{"dev"})
+		testConfData := prepareYamlConfig("100MB", 31, 45, "127.0.0.1:81", listenValue, "client1", []string{"dev"})
 		result, _ := ValidateConf(testConfData)
 		assert.True(t, result, "Should be true")
 	}
@@ -58,22 +58,22 @@ func TestShouldNotValidateListenConf(t *testing.T) {
 	testWrongListenData := []string{"", "-", " ", "aaa", ":bbb", "c:"}
 
 	for _, listenWrongValue := range testWrongListenData {
-		testConfData := prepareYamlConfig("20MB", 31, 45, "127.0.0.1:82", listenWrongValue, nil, "client1", []string{"dev"})
+		testConfData := prepareYamlConfig("20MB", 31, 45, "127.0.0.1:82", listenWrongValue, "client1", []string{"dev"})
 		result, _ := ValidateConf(testConfData)
 		assert.False(t, result, "Should be false")
 	}
 }
 
 func TestShouldValidateConfWithRegexp(t *testing.T) {
-	testConfData := prepareYamlConfig("40MB", 17, 51, "127.0.0.1:83", ":80", nil, "client1", []string{"dev"})
+	testConfData := prepareYamlConfig("40MB", 17, 51, "127.0.0.1:83", ":80", "client1", []string{"dev"})
 
 	result, _ := ValidateConf(testConfData)
 
 	assert.True(t, result, "Should be true")
 }
 
-func TestShouldNotValidateConfWithWrongBodyMaxSizeValueinRegexp(t *testing.T) {
-	testConfData := prepareYamlConfig("0", 0, 1, "127.0.0.1:84", ":80", nil, "client1", []string{"dev"})
+func TestShouldNotValidateConfWithWrongBodyMaxSizeValue(t *testing.T) {
+	testConfData := prepareYamlConfig("0", 0, 1, "127.0.0.1:84", ":80", "client1", []string{"dev"})
 
 	result, validationErrors := ValidateConf(testConfData)
 
@@ -83,7 +83,7 @@ func TestShouldNotValidateConfWithWrongBodyMaxSizeValueinRegexp(t *testing.T) {
 
 func TestShouldValidateConfMaintainedBackendWhenNotEmpty(t *testing.T) {
 	maintainedBackendHost := "127.0.0.1:85"
-	testConfData := prepareYamlConfig("112MB", 21, 32, maintainedBackendHost, ":80", nil, "client1", []string{"dev"})
+	testConfData := prepareYamlConfig("112MB", 21, 32, maintainedBackendHost, ":80", "client1", []string{"dev"})
 
 	result, _ := ValidateConf(testConfData)
 
@@ -92,7 +92,7 @@ func TestShouldValidateConfMaintainedBackendWhenNotEmpty(t *testing.T) {
 
 func TestShouldValidateConfMaintainedBackendWhenEmpty(t *testing.T) {
 	maintainedBackendHost := ""
-	testConfData := prepareYamlConfig("113MB", 22, 33, maintainedBackendHost, ":80", nil, "client1", []string{"dev"})
+	testConfData := prepareYamlConfig("113MB", 22, 33, maintainedBackendHost, ":80", "client1", []string{"dev"})
 
 	result, _ := ValidateConf(testConfData)
 
@@ -101,7 +101,7 @@ func TestShouldValidateConfMaintainedBackendWhenEmpty(t *testing.T) {
 
 func TestShouldValidateConfClientNameWithMinLenght(t *testing.T) {
 	clientName := "c"
-	testConfData := prepareYamlConfig("114MB", 22, 33, "", ":80", nil, clientName, []string{"dev"})
+	testConfData := prepareYamlConfig("114MB", 22, 33, "", ":80", clientName, []string{"dev"})
 
 	result, _ := ValidateConf(testConfData)
 
@@ -110,7 +110,7 @@ func TestShouldValidateConfClientNameWithMinLenght(t *testing.T) {
 
 func TestShouldNotValidateConfClientNameWhenEmpty(t *testing.T) {
 	clientName := ""
-	testConfData := prepareYamlConfig("115MB", 22, 33, "", ":80", nil, clientName, []string{"dev"})
+	testConfData := prepareYamlConfig("115MB", 22, 33, "", ":80", clientName, []string{"dev"})
 
 	result, _ := ValidateConf(testConfData)
 
@@ -118,7 +118,7 @@ func TestShouldNotValidateConfClientNameWhenEmpty(t *testing.T) {
 }
 
 func TestShouldValidateConfClientClustersValues(t *testing.T) {
-	testConfData := prepareYamlConfig("115MB", 22, 33, "", ":80", nil, "client", []string{"prod", "jprod"})
+	testConfData := prepareYamlConfig("115MB", 22, 33, "", ":80", "client", []string{"prod", "jprod"})
 
 	result, _ := ValidateConf(testConfData)
 
@@ -126,7 +126,7 @@ func TestShouldValidateConfClientClustersValues(t *testing.T) {
 }
 
 func TestShouldNotValidateConfClientClustersValuesWhenEmpty(t *testing.T) {
-	testConfData := prepareYamlConfig("116MB", 22, 33, "", ":80", nil, "client", []string{"prod", "  "})
+	testConfData := prepareYamlConfig("116MB", 22, 33, "", ":80", "client", []string{"prod", "  "})
 
 	result, validationErrors := ValidateConf(testConfData)
 
@@ -135,7 +135,7 @@ func TestShouldNotValidateConfClientClustersValuesWhenEmpty(t *testing.T) {
 }
 
 func TestShouldNotValidateConfClientClustersValuesWhenDuplicated(t *testing.T) {
-	testConfData := prepareYamlConfig("117MB", 22, 33, "", ":80", nil, "client", []string{"jprod", "jprod"})
+	testConfData := prepareYamlConfig("117MB", 22, 33, "", ":80", "client", []string{"jprod", "jprod"})
 
 	result, validationErrors := ValidateConf(testConfData)
 
@@ -187,7 +187,7 @@ func TestAdditionalHeadersYamlParsingFailureWhenKeyIsEmpty(t *testing.T) {
 	testyaml := AdditionalHeaders{}
 	err := yaml.Unmarshal(incorrect, &testyaml)
 
-	assert.Error(t, err, "Missing protocol should return error")
+	assert.Error(t, err, "Empty key should return error")
 }
 
 func TestAdditionalHeadersYamlParsingFailureWhenValueIsEmpty(t *testing.T) {
@@ -198,16 +198,30 @@ func TestAdditionalHeadersYamlParsingFailureWhenValueIsEmpty(t *testing.T) {
 	testyaml := AdditionalHeaders{}
 	err := yaml.Unmarshal(incorrect, &testyaml)
 
-	assert.Error(t, err, "Missing protocol should return error")
+	assert.Error(t, err, "Empty value should return error")
+}
+
+func TestDurationYamlParsingWithSuccess(t *testing.T) {
+	correct := []byte(`1s`)
+	testyaml := metrics.Interval{}
+	err := yaml.Unmarshal(correct, &testyaml)
+
+	assert.NoError(t, err, "Should be correct")
+}
+
+func TestDurationYamlParsingWithIncorrectValue(t *testing.T) {
+	correct := []byte(`23ss`)
+	testyaml := metrics.Interval{}
+	err := yaml.Unmarshal(correct, &testyaml)
+
+	assert.Error(t, err, "Missing duration should return error")
 }
 
 func prepareYamlConfig(bodyMaxSize string, idleConnTimeoutInp time.Duration, responseHeaderTimeoutInp time.Duration,
-	maintainedBackendHost string, listen string, syncLogMethods []SyncLogMethod, clientCfgName string,
+	maintainedBackendHost string, listen string, clientCfgName string,
 	clientClusters []string) YamlConfig {
 
-	if syncLogMethods == nil {
-		syncLogMethods = []SyncLogMethod{{method: "POST"}}
-	}
+	syncLogMethods := []SyncLogMethod{{method: "POST"}}
 
 	url1 := url.URL{
 		Scheme: "http",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,11 +3,12 @@ package config
 import (
 	"testing"
 
+	"net/url"
+	"time"
+
 	"github.com/allegro/akubra/metrics"
 	"github.com/go-yaml/yaml"
 	"github.com/stretchr/testify/assert"
-	"net/url"
-	"time"
 )
 
 type TestYaml struct {
@@ -129,12 +130,12 @@ func prepareYamlConfig(bodyMaxSize string, idleConnTimeoutInp time.Duration, res
 		Scheme: "http",
 		Host:   "127.0.0.1:8080",
 	}
-	yamlUrl := []YAMLURL{{&url1}}
+	yamlURL := []YAMLURL{{&url1}}
 
 	maxIdleConns := 1
 	maxIdleConnsPerHost := 2
 	clusters := map[string]ClusterConfig{"test": {
-		yamlUrl,
+		yamlURL,
 		"replicator",
 		1,
 		map[string]string{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-yaml/yaml"
 	"github.com/stretchr/testify/assert"
+	//"github.com/allegro/akubra/log"
 )
 
 type TestYaml struct {
@@ -25,10 +26,120 @@ func TestYAMLURLParsingFailure(t *testing.T) {
 	assert.Error(t, err, "Missing protocol should return error")
 }
 
-func TestYAMLURLParsingEmpty(t *testing.T) {
-	incorrect := []byte(`field:`)
+//func TestYAMLURLParsingEmpty(t *testing.T) {
+//	incorrect := []byte(`field: "1"`)
+//	testyaml := TestYaml{}
+//	err := yaml.Unmarshal(incorrect, &testyaml)
+//	assert.NoError(t, err, "Should not even try to parse")
+//	assert.Nil(t, testyaml.Field.URL, "Should be nil")
+//}
+
+func TestListenYamlParameterValidation(t *testing.T) {
+	incorrect := []byte(`Listen: ":8080"`)
 	testyaml := TestYaml{}
 	err := yaml.Unmarshal(incorrect, &testyaml)
 	assert.NoError(t, err, "Should not even try to parse")
 	assert.Nil(t, testyaml.Field.URL, "Should be nil")
 }
+/*
+
+func TestShouldValidateListenConf(t *testing.T) {
+	testListenData := []string{"aaa", "127.0.0.1", "127.0.0.1:8080", ":8080", ":80"}
+
+	for _, listenValue := range testListenData {
+		testConfData := prepareYamlConfig("20", "31", "45", "", listenValue)
+		result, _ := ValidateConf(testConfData)
+		assert.True(t, result, "Should be true")
+	}
+}
+func TestShouldNotValidateListenConf(t *testing.T) {
+	testWrongListenData := []string{"", "-", " ", "aaa", ":1234567", "0:0"}
+
+	for _, listenWrongValue := range testWrongListenData {
+		testConfData := prepareYamlConfig("20", "31", "45", "", listenWrongValue)
+		result, _ := ValidateConf(testConfData)
+		assert.False(t, result, "Should be false")
+	}
+}
+
+func TestShouldValidateConfWithRegexp(t *testing.T) {
+	testConfData := prepareYamlConfig("1", "10", "91", "", "")
+
+	result, _ := ValidateConf(testConfData)
+
+	assert.True(t, result, "Should be true")
+}
+
+func TestShouldNotValidateConfWithWrongValuesinRegexp(t *testing.T) {
+	testConfData := prepareYamlConfig("0", "aa", "", "", "")
+
+	result, validationErrors := ValidateConf(testConfData)
+
+	assert.Contains(t, validationErrors, "ConnLimit")
+	assert.Contains(t, validationErrors, "ConnectionTimeout")
+	assert.Contains(t, validationErrors, "ConnectionDialTimeout")
+	assert.False(t, result, "Should be false")
+}
+
+func TestShouldValidateConfMaintainedBackendWhenNotEmpty(t *testing.T) {
+	maintainedBackend := "127.0.0.1:8044ąąą"
+	testConfData := prepareYamlConfig("11", "22", "33", maintainedBackend, "")
+
+	result, _ := ValidateConf(testConfData)
+
+	assert.True(t, result, "Should be true")
+}
+
+func prepareYamlConfig(bodyMaxSize string, connectionTimeout string, connectionDialTimeout string,
+	maintainedBackend string, listen string) (YamlConfig) {
+
+	backends := []YAMLURL{}
+
+	additionalRequestHeaders := map[string]string{
+		"Cache-Control": "public, s-maxage=600, max-age=600",
+	}
+
+	additionalResponseHeaders := map[string]string{
+		"Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+	}
+
+	syncLogMethods := make([]SYNCLOGMETHOD, 1) {
+		"POST",
+	}
+
+	maxIdleConns := 1
+	maxIdleConnsPerHost := 2
+	idleConnTimeout := "1s"
+	responseHeaderTimeout := "2s"
+	clusters := map[string]ClusterConfig{"test": {
+		{"127.0.0.1:8080"},
+		"replicator",
+		1,
+		map[string]string{},
+	}}
+	maintainedBackends := map[]{YAMLURL{"http://127.0.0.2:8081",}}
+	client := ClientConfig{"a", []string{"test"},}
+	tmpLogger := log.LoggerConfig{false,false,false,"/tmp/1","/tmp/2","/tmp/3",}
+	logging := LoggingConfig{tmpLogger, tmpLogger, tmpLogger, tmpLogger,}
+	metrics := nil
+	disableKeepAlive := false
+	return YamlConfig{
+		listen,
+		backends,
+		bodyMaxSize,
+		maxIdleConns,
+		maxIdleConnsPerHost,
+		idleConnTimeout,
+		responseHeaderTimeout,
+		clusters,
+		additionalRequestHeaders,
+		additionalResponseHeaders,
+		maintainedBackends,
+		syncLogMethods,
+		&client,
+		logging,
+		metrics,
+		disableKeepAlive,
+	}
+}
+*/

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,10 +15,6 @@ type TestYaml struct {
 	Field YAMLUrl
 }
 
-type TestAdditionalHeadersYaml struct {
-	HeaderField AdditionalHeaders
-}
-
 func TestYAMLUrlParsingSuccessful(t *testing.T) {
 	correct := []byte(`field: http://golang.org:80/pkg/net`)
 	testyaml := TestYaml{}
@@ -33,13 +29,13 @@ func TestYAMLUrlParsingFailure(t *testing.T) {
 	assert.Error(t, err, "Missing protocol should return error")
 }
 
-//func TestYAMLUrlParsingEmpty(t *testing.T) {
-//	incorrect := []byte(`field: "1"`)
-//	testyaml := TestYaml{}
-//	err := yaml.Unmarshal(incorrect, &testyaml)
-//	assert.NoError(t, err, "Should not even try to parse")
-//	assert.Nil(t, testyaml.Field.URL, "Should be nil")
-//}
+func TestYAMLUrlParsingEmpty(t *testing.T) {
+	incorrect := []byte(`field: "1"`)
+	testyaml := YAMLUrl{}
+	err := yaml.Unmarshal(incorrect, &testyaml)
+	assert.Error(t, err, "Should not even try to parse")
+	assert.Nil(t, testyaml.URL, "Should be nil")
+}
 
 func TestListenYamlParameterValidation(t *testing.T) {
 	incorrect := []byte(`Listen: ":8080"`)
@@ -172,28 +168,38 @@ func TestShouldNotValidateWrongSyncLogMethod(t *testing.T) {
 	assert.NotNil(t, errors)
 }
 
-/*
 func TestAdditionalHeadersYamlParsingSuccessful(t *testing.T) {
-	correct := []byte(`HeaderField:\n  'FieldKey': "FieldValue"`)
-	testyaml := TestAdditionalHeadersYaml{}
-	err := yaml.Unmarshal(correct, &testyaml)
+	correct := `
+'Access-Control-Allow-Credentials': "true"
+'Access-Control-Allow-Methods': "GET, POST, OPTIONS"
+`
+	testyaml := AdditionalHeaders{}
+	err := yaml.Unmarshal([]byte(correct), &testyaml)
+
 	assert.NoError(t, err, "Should be correct")
 }
 
 func TestAdditionalHeadersYamlParsingFailureWhenKeyIsEmpty(t *testing.T) {
-	incorrect := []byte(`HeaderField:\n  '': "FieldValue2"`)
-	testyaml := TestAdditionalHeadersYaml{}
+	incorrect := []byte(`
+'Access-Control-Allow-Credentials': "true"
+'': "GET, POST, OPTIONS"
+`)
+	testyaml := AdditionalHeaders{}
 	err := yaml.Unmarshal(incorrect, &testyaml)
+
 	assert.Error(t, err, "Missing protocol should return error")
 }
 
 func TestAdditionalHeadersYamlParsingFailureWhenValueIsEmpty(t *testing.T) {
-	incorrect := []byte(`HeaderField:\n  'FieldKey3': ""`)
-	testyaml := TestAdditionalHeadersYaml{}
+	incorrect := []byte(`
+'Access-Control-Allow-Methods': ""
+'Access-Control-Allow-Credentials': "true"
+`)
+	testyaml := AdditionalHeaders{}
 	err := yaml.Unmarshal(incorrect, &testyaml)
+
 	assert.Error(t, err, "Missing protocol should return error")
 }
-*/
 
 func prepareYamlConfig(bodyMaxSize string, idleConnTimeoutInp time.Duration, responseHeaderTimeoutInp time.Duration,
 	maintainedBackendHost string, listen string, syncLogMethods []SyncLogMethod, clientCfgName string,

--- a/config/validator.go
+++ b/config/validator.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	set "github.com/deckarep/golang-set"
+)
+
+// NoEmptyValuesInSliceValidator for strings in slice
+func NoEmptyValuesInSliceValidator(v interface{}, param string) error {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Slice {
+		for i := 0; i < val.Len(); i++ {
+			e := val.Index(i)
+			switch e.Kind() {
+			case reflect.String:
+				val := strings.TrimSpace(e.String())
+				if len(val) == 0 {
+					return fmt.Errorf("NoEmptyValuesInSliceValidator: Empty value in parameter: %q", param)
+				}
+			default:
+				return fmt.Errorf("NoEmptyValuesInSliceValidator: Invalid Kind: %v in parameter: %q. Only kind 'String' is supported", e.Kind(), param)
+			}
+		}
+	} else {
+		return errors.New("NoEmptyValuesInSliceValidator: validates only Slice kind")
+	}
+	return nil
+}
+
+// UniqueValuesInSliceValidator for strings in slice
+func UniqueValuesInSliceValidator(v interface{}, param string) error {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Slice {
+		vals := []string{}
+		uniqueVals := set.NewSet()
+		for i := 0; i < val.Len(); i++ {
+			e := val.Index(i)
+			switch e.Kind() {
+			case reflect.String:
+				val := e.String()
+				vals = append(vals, val)
+				uniqueVals.Add(val)
+			default:
+				return fmt.Errorf("UniqueValuesInSliceValidator: Invalid Kind: %v in parameter: %q. Only kind 'String' is supported", e.Kind(), param)
+			}
+		}
+		if len(vals) != len(uniqueVals.ToSlice()) {
+			return fmt.Errorf("UniqueValuesInSliceValidator: Duplicated values detected in parameter: %q", param)
+		}
+	} else {
+		return errors.New("UniqueValuesInSliceValidator: validates only Slice kind")
+	}
+	return nil
+}

--- a/config/validator.go
+++ b/config/validator.go
@@ -48,7 +48,7 @@ func UniqueValuesInSliceValidator(v interface{}, param string) error {
 				return fmt.Errorf("UniqueValuesInSliceValidator: Invalid Kind: %v in parameter: %q. Only kind 'String' is supported", e.Kind(), param)
 			}
 		}
-		if len(vals) != len(uniqueVals.ToSlice()) {
+		if len(vals) != uniqueVals.Cardinality() {
 			return fmt.Errorf("UniqueValuesInSliceValidator: Duplicated values detected in parameter: %q", param)
 		}
 	} else {

--- a/config/validator.go
+++ b/config/validator.go
@@ -56,3 +56,41 @@ func UniqueValuesInSliceValidator(v interface{}, param string) error {
 	}
 	return nil
 }
+
+// ClientClustersEntryLogicalValidator validate Client->Clusters entry and make sure that all required clusters are defined
+func (c *YamlConfig) ClientClustersEntryLogicalValidator(valid *bool, validationErrors *map[string][]error) {
+	errorsList := make(map[string][]error)
+
+	if len(c.Client.Clusters) == 0 {
+		*valid = false
+		errorDetail := []error{errors.New("Empty clusters definition")}
+		errorsList["ClientClustersEntryLogicalValidator"] = errorDetail
+	} else {
+		for _, clusterName := range c.Client.Clusters {
+			_, exists := c.Clusters[clusterName]
+			if !exists {
+				*valid = false
+				errorDetail := []error{fmt.Errorf("Undefined cluster: %q - not all required clusters are defined", clusterName)}
+				errorsList["ClientClustersEntryLogicalValidator"] = errorDetail
+			}
+		}
+	}
+	*validationErrors = mergeErrors(*validationErrors, errorsList)
+}
+
+func mergeErrors(maps ...map[string][]error) (output map[string][]error) {
+	size := len(maps)
+	if size == 0 {
+		return output
+	}
+	if size == 1 {
+		return maps[0]
+	}
+	output = make(map[string][]error)
+	for _, m := range maps {
+		for k, v := range m {
+			output[k] = v
+		}
+	}
+	return output
+}

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"github.com/go-validator/validator"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type CustomItemsTestUnique struct {
+	Items []string `validate:"UniqueValuesSlice=Items"`
+}
+
+type CustomItemsTestNoEmpty struct {
+	Items []string `validate:"NoEmptyValuesSlice=Items"`
+}
+
+func TestShouldValidateWhenValuesInSliceAreNotDuplicated(t *testing.T) {
+	var data CustomItemsTestUnique
+	data.Items = []string{"item001", "item002"}
+
+	validator.SetValidationFunc("UniqueValuesSlice", UniqueValuesInSliceValidator)
+	valid, _ := validator.Validate(data)
+
+	assert.True(t, valid, "Should be true")
+}
+
+func TestShouldNotValidateWhenValuesInSliceAreDuplicated(t *testing.T) {
+	var data CustomItemsTestUnique
+	data.Items = []string{"not_unique", "not_unique"}
+
+	validator.SetValidationFunc("UniqueValuesSlice", UniqueValuesInSliceValidator)
+	valid, validationErrors := validator.Validate(data)
+
+	assert.Contains(t, validationErrors, "Items")
+	assert.False(t, valid, "Should be false")
+}
+
+func TestShouldValidateWhenValuesInSliceAreNoEmpty(t *testing.T) {
+	var data CustomItemsTestNoEmpty
+	data.Items = []string{"i1", "i2"}
+
+	validator.SetValidationFunc("NoEmptyValuesSlice", NoEmptyValuesInSliceValidator)
+	valid, _ := validator.Validate(data)
+
+	assert.True(t, valid, "Should be true")
+}
+
+func TestShouldNotValidateWhenValuesInSliceAreEmpty(t *testing.T) {
+	var data CustomItemsTestNoEmpty
+	data.Items = []string{"value", "  "}
+
+	validator.SetValidationFunc("NoEmptyValuesSlice", NoEmptyValuesInSliceValidator)
+	valid, validationErrors := validator.Validate(data)
+
+	assert.Contains(t, validationErrors, "Items")
+	assert.False(t, valid, "Should be false")
+}

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	shardingconfig "github.com/allegro/akubra/sharding/config"
 	"github.com/go-validator/validator"
 	"github.com/stretchr/testify/assert"
 )
@@ -54,5 +55,43 @@ func TestShouldNotValidateWhenValuesInSliceAreEmpty(t *testing.T) {
 	valid, validationErrors := validator.Validate(data)
 
 	assert.Contains(t, validationErrors, "Items")
+	assert.False(t, valid, "Should be false")
+}
+
+func TestShouldValidClientClustersEntryLogicalValidator(t *testing.T) {
+	existsClusterName := "cluster1test"
+	valid := true
+	validationErrors := make(map[string][]error)
+	var size shardingconfig.HumanSizeUnits
+	size.SizeInBytes = 2048
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{existsClusterName})
+	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
+
+	assert.Len(t, validationErrors, 0, "Should not be errors")
+	assert.True(t, valid, "Should be true")
+}
+
+func TestShouldNotValidClientClustersEntryLogicalValidatorWhenNotExistsCluster(t *testing.T) {
+	noExistsClusterName := "noExistsClusterName"
+	valid := true
+	validationErrors := make(map[string][]error)
+	var size shardingconfig.HumanSizeUnits
+	size.SizeInBytes = 2048
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{noExistsClusterName})
+	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
+
+	assert.Len(t, validationErrors, 1, "Should not be errors")
+	assert.False(t, valid, "Should be false")
+}
+
+func TestShouldNotValidClientClustersEntryLogicalValidatorWhenEmptyClustersDefinition(t *testing.T) {
+	valid := true
+	validationErrors := make(map[string][]error)
+	var size shardingconfig.HumanSizeUnits
+	size.SizeInBytes = 2048
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{})
+	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
+
+	assert.Len(t, validationErrors, 1, "Should not be errors")
 	assert.False(t, valid, "Should be false")
 }

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -15,7 +15,7 @@ type CustomItemsTestNoEmpty struct {
 	Items []string `validate:"NoEmptyValuesSlice=Items"`
 }
 
-func TestShouldValidateWhenValuesInSliceAreNotDuplicated(t *testing.T) {
+func TestShouldValidateWhenValuesInSliceAreUnique(t *testing.T) {
 	var data CustomItemsTestUnique
 	data.Items = []string{"item001", "item002"}
 

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"testing"
+
 	"github.com/go-validator/validator"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type CustomItemsTestUnique struct {

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -58,33 +58,33 @@ func TestShouldNotValidateWhenValuesInSliceAreEmpty(t *testing.T) {
 	assert.False(t, valid, "Should be false")
 }
 
-func TestShouldValidClientClustersEntryLogicalValidator(t *testing.T) {
-	existsClusterName := "cluster1test"
+func TestShouldPassClientClustersEntryLogicalValidator(t *testing.T) {
+	existingClusterName := "cluster1test"
 	valid := true
 	validationErrors := make(map[string][]error)
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{existsClusterName})
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{existingClusterName})
 	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
 
 	assert.Len(t, validationErrors, 0, "Should not be errors")
 	assert.True(t, valid, "Should be true")
 }
 
-func TestShouldNotValidClientClustersEntryLogicalValidatorWhenNotExistsCluster(t *testing.T) {
-	noExistsClusterName := "noExistsClusterName"
+func TestShouldNotPassClientClustersEntryLogicalValidatorWhenClusterDoesNotExist(t *testing.T) {
+	notExistingClusterName := "notExistingClusterName"
 	valid := true
 	validationErrors := make(map[string][]error)
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{noExistsClusterName})
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{notExistingClusterName})
 	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
 
-	assert.Len(t, validationErrors, 1, "Should not be errors")
+	assert.Len(t, validationErrors, 1, "Should be one error")
 	assert.False(t, valid, "Should be false")
 }
 
-func TestShouldNotValidClientClustersEntryLogicalValidatorWhenEmptyClustersDefinition(t *testing.T) {
+func TestShouldNotPassClientClustersEntryLogicalValidatorWhenEmptyClustersDefinition(t *testing.T) {
 	valid := true
 	validationErrors := make(map[string][]error)
 	var size shardingconfig.HumanSizeUnits
@@ -92,6 +92,6 @@ func TestShouldNotValidClientClustersEntryLogicalValidatorWhenEmptyClustersDefin
 	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{})
 	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
 
-	assert.Len(t, validationErrors, 1, "Should not be errors")
+	assert.Len(t, validationErrors, 1, "Should be one error")
 	assert.False(t, valid, "Should be false")
 }

--- a/examples/akubra.config.dist
+++ b/examples/akubra.config.dist
@@ -5,13 +5,13 @@ AdditionalResponseHeaders:
     'Access-Control-Allow-Origin': "*"
     'Access-Control-Allow-Credentials': "true"
     'Access-Control-Allow-Methods': "GET, POST, OPTIONS"
-    'Access-Control-Allow-Headers': "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
+    'Access-Control-Allow-Headers': 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-CSRFToken'
 # Additional headers added to backend response
 AdditionalRequestHeaders:
     'Cache-Control': "public, s-maxage=600, max-age=600"
     'X-Akubra-Version': '0.9.26'
 # Maximum accepted body size
-BodyMaxSize: "100M"
+BodyMaxSize: "100MB"
 # Backend in maintenance mode. Akubra will skip this endpoint
 # MaxIdleConns see: https://golang.org/pkg/net/http/#Transport
 # Default 0 (no limit)

--- a/glide.lock
+++ b/glide.lock
@@ -49,3 +49,9 @@ testImports:
   subpackages:
   - assert
   - require
+- name: github.com/go-validator/validator
+  version: 4379dff89709877fa1b057d23b11bfe0c361dfd3
+- name: gopkg.in/yaml.v2
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+- name: github.com/rcrowley/go-metrics
+  version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,11 @@ testImport:
   version: ~1.1.x
   subpackages:
   - assert
+- package: github.com/go-validator/validator
+  version: v1
+- package: gopkg.in/yaml.v2
+  version: v2
+- package: github.com/rcrowley/go-metrics
+  version: master
+  subpackages:
+  - exp

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,7 @@ testImport:
   version: ~1.1.x
   subpackages:
   - assert
+  - require
 - package: github.com/go-validator/validator
   version: v1
 - package: gopkg.in/yaml.v2

--- a/httphandler/roundtripper_decorators.go
+++ b/httphandler/roundtripper_decorators.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/allegro/akubra/config"
 	"github.com/allegro/akubra/log"
+	shardingconfig "github.com/allegro/akubra/sharding/config"
 )
 
 // Decorator is http.RoundTripper interface wrapper
@@ -55,8 +55,8 @@ func AccessLogging(logger log.Logger) Decorator {
 }
 
 type headersSuplier struct {
-	requestHeaders  config.AdditionalHeaders
-	responseHeaders config.AdditionalHeaders
+	requestHeaders  shardingconfig.AdditionalHeaders
+	responseHeaders shardingconfig.AdditionalHeaders
 	roundTripper    http.RoundTripper
 }
 
@@ -95,7 +95,7 @@ func (hs *headersSuplier) RoundTrip(req *http.Request) (resp *http.Response, err
 }
 
 // HeadersSuplier creates Decorator which adds headers to request and response
-func HeadersSuplier(requestHeaders, responseHeaders config.AdditionalHeaders) Decorator {
+func HeadersSuplier(requestHeaders, responseHeaders shardingconfig.AdditionalHeaders) Decorator {
 	return func(roundTripper http.RoundTripper) http.RoundTripper {
 		return &headersSuplier{
 			requestHeaders:  requestHeaders,

--- a/httphandler/roundtripper_decorators.go
+++ b/httphandler/roundtripper_decorators.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/allegro/akubra/config"
 	"github.com/allegro/akubra/log"
 )
 
@@ -54,8 +55,8 @@ func AccessLogging(logger log.Logger) Decorator {
 }
 
 type headersSuplier struct {
-	requestHeaders  map[string]string
-	responseHeaders map[string]string
+	requestHeaders  config.AdditionalHeaders
+	responseHeaders config.AdditionalHeaders
 	roundTripper    http.RoundTripper
 }
 
@@ -94,7 +95,7 @@ func (hs *headersSuplier) RoundTrip(req *http.Request) (resp *http.Response, err
 }
 
 // HeadersSuplier creates Decorator which adds headers to request and response
-func HeadersSuplier(requestHeaders, responseHeaders map[string]string) Decorator {
+func HeadersSuplier(requestHeaders, responseHeaders config.AdditionalHeaders) Decorator {
 	return func(roundTripper http.RoundTripper) http.RoundTripper {
 		return &headersSuplier{
 			requestHeaders:  requestHeaders,

--- a/log/config/config.go
+++ b/log/config/config.go
@@ -1,0 +1,11 @@
+package config
+
+import "github.com/allegro/akubra/log"
+
+// LoggingConfig contains Loggers configuration
+type LoggingConfig struct {
+	Accesslog      log.LoggerConfig `yaml:"Accesslog,omitempty"`
+	Synclog        log.LoggerConfig `yaml:"Synclog,omitempty"`
+	Mainlog        log.LoggerConfig `yaml:"Mainlog,omitempty"`
+	ClusterSyncLog log.LoggerConfig `yaml:"ClusterSynclog,omitempty"`
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 	"github.com/allegro/akubra/sharding"
 )
 
+// YamlValidationErrorExitCode for problems with YAML config validation
+const YamlValidationErrorExitCode = 20
+
 type service struct {
 	conf config.Config
 }
@@ -49,7 +52,7 @@ func main() {
 	valid, errs := config.ValidateConf(conf.YamlConfig)
 	if !valid {
 		log.Println("Custom YAML Configuration validation error:", errs)
-		os.Exit(20)
+		os.Exit(YamlValidationErrorExitCode)
 	}
 	log.Println("Configuration checked - OK.")
 

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatalf("Improperly configured %s", err)
 	}
 
-	valid, errs := config.ValidateConf(conf.YamlConfig)
+	valid, errs := config.ValidateConf(conf.YamlConfig, true)
 	if !valid {
 		log.Println("Custom YAML Configuration validation error:", errs)
 		os.Exit(YamlValidationErrorExitCode)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	graceful "gopkg.in/tylerb/graceful.v1"
@@ -15,16 +16,24 @@ import (
 	"github.com/allegro/akubra/sharding"
 )
 
+type service struct {
+	conf config.Config
+}
+
 var (
 	// filled by linker
 	version = "development"
 
 	// CLI flags
 	configFile = kingpin.
-			Flag("config", "Configuration file e.g.: \"conf/dev.yaml\"").
+			Flag("config", "Configuration file path e.g.: \"conf/dev.yaml\"").
 			Short('c').
 			Required().
 			ExistingFile()
+	testConfig = kingpin.
+			Flag("test-config", "Testing only configuration file from 'config' arg. (app. not starting).").
+			Short('t').
+			Bool()
 )
 
 func main() {
@@ -37,17 +46,26 @@ func main() {
 		log.Fatalf("Improperly configured %s", err)
 	}
 
+	valid, errs := config.ValidateConf(conf.YamlConfig)
+	if !valid {
+		log.Println("Custom YAML Configuration validation error:", errs)
+		os.Exit(20)
+	}
+	log.Println("Configuration checked - OK.")
+
+	if *testConfig {
+		os.Exit(0)
+	}
+
 	mainlog := conf.Mainlog
 	mainlog.Printf("starting on port %s", conf.Listen)
+	mainlog.Printf("backends %s", conf.Backends)
+
 	srv := newService(conf)
 	startErr := srv.start()
 	if startErr != nil {
 		mainlog.Fatalf("Could not start service, reason: %q", startErr.Error())
 	}
-}
-
-type service struct {
-	conf config.Config
 }
 
 func (s *service) start() error {
@@ -75,7 +93,7 @@ func (s *service) start() error {
 	listener, err := net.Listen("tcp", s.conf.Listen)
 
 	if err != nil {
-		return err
+		log.Fatalln(err)
 	}
 	return srv.Serve(listener)
 }

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"fmt"
 	"time"
+	"fmt"
 )
 
 // Interval is time.Duration wrapper

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"time"
 	"fmt"
+	"time"
 )
 
 // Interval is time.Duration wrapper

--- a/sharding/config/config.go
+++ b/sharding/config/config.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ClusterConfig defines cluster configuration
+type ClusterConfig struct {
+	// Backends should contain s3 backend urls
+	Backends []YAMLUrl `yaml:"Backends,omitempty"`
+	// Type, currently replicator is only option
+	Type string `yaml:"Type,omitempty"`
+	// Points how much load cluster should handle
+	Weight int `yaml:"Weight,omitempty"`
+	// Cluster type specific options
+	Options map[string]string `yaml:"Options,omitempty"`
+}
+
+// ClientConfig keeps information about client setup
+type ClientConfig struct {
+	// Client name
+	Name string `yaml:"Name,omitempty" validate:"regexp=^([a-zA-Z0-9_-]+)$"`
+	// List of clusters name
+	Clusters []string `yaml:"Clusters,omitempty" validate:"NoEmptyValuesSlice=Clusters,UniqueValuesSlice=Clusters"`
+}
+
+// YAMLUrl type fields in yaml configuration will parse urls
+type YAMLUrl struct {
+	*url.URL
+}
+
+// SyncLogMethod type fields in yaml configuration will parse list of HTTP methods
+type SyncLogMethod struct {
+	Method string
+}
+
+// AdditionalHeaders type fields in yaml configuration will parse list of special headers
+type AdditionalHeaders map[string]string
+
+// UnmarshalYAML for YAMLUrl
+func (j *YAMLUrl) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	url, err := url.Parse(s)
+	if url.Host == "" {
+		return fmt.Errorf("url should match proto://host[:port]/path scheme - got %q", s)
+	}
+	j.URL = url
+	return err
+}
+
+// UnmarshalYAML for SyncLogMethod
+func (j *SyncLogMethod) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	method := fmt.Sprintf("%v", s)
+	switch method {
+	case "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS":
+		break
+	default:
+		return fmt.Errorf("Sync log method should be one from [GET, POST, DELETE, HEAD, OPTIONS] - got %q", s)
+	}
+	j.Method = method
+	return nil
+}
+
+// UnmarshalYAML for AdditionalHeaders
+func (j *AdditionalHeaders) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var headers map[string]string
+	if err := unmarshal(&headers); err != nil {
+		return err
+	}
+
+	for key, value := range headers {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("Empty additional header with value: %q", value)
+		}
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("Empty additional header with key: %q", key)
+		}
+	}
+	return nil
+}

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -9,6 +9,7 @@ import (
 	"github.com/allegro/akubra/config"
 	"github.com/allegro/akubra/httphandler"
 	"github.com/allegro/akubra/log"
+	shardingconfig "github.com/allegro/akubra/sharding/config"
 	"github.com/allegro/akubra/transport"
 	units "github.com/docker/go-units"
 	"github.com/serialx/hashring"
@@ -17,13 +18,13 @@ import (
 type cluster struct {
 	http.RoundTripper
 	weight   int
-	backends []config.YAMLUrl
+	backends []shardingconfig.YAMLUrl
 	name     string
 }
 
 func newMultiBackendCluster(transp http.RoundTripper,
 	multiResponseHandler transport.MultipleResponsesHandler,
-	clusterConf config.ClusterConfig, name string, maintainedBackends []config.YAMLUrl) cluster {
+	clusterConf shardingconfig.ClusterConfig, name string, maintainedBackends []shardingconfig.YAMLUrl) cluster {
 	backends := make([]url.URL, len(clusterConf.Backends))
 
 	for i, backend := range clusterConf.Backends {
@@ -72,8 +73,8 @@ func (rf ringFactory) getCluster(name string) (cluster, error) {
 	return s3cluster, nil
 }
 
-func (rf ringFactory) uniqBackends(clientCfg config.ClientConfig) ([]url.URL, error) {
-	allBackendsSet := make(map[config.YAMLUrl]bool)
+func (rf ringFactory) uniqBackends(clientCfg shardingconfig.ClientConfig) ([]url.URL, error) {
+	allBackendsSet := make(map[shardingconfig.YAMLUrl]bool)
 	log.Debugf("client %v", clientCfg.Clusters)
 	for _, name := range clientCfg.Clusters {
 		log.Debugf("cluster %s", name)
@@ -93,7 +94,7 @@ func (rf ringFactory) uniqBackends(clientCfg config.ClientConfig) ([]url.URL, er
 	return uniqBackendsSlice, nil
 }
 
-func (rf ringFactory) getClientClusters(clientCfg config.ClientConfig) map[string]int {
+func (rf ringFactory) getClientClusters(clientCfg shardingconfig.ClientConfig) map[string]int {
 	res := make(map[string]int)
 	for _, clusterName := range clientCfg.Clusters {
 		cluster := rf.conf.Clusters[clusterName]
@@ -130,7 +131,7 @@ func (rf ringFactory) createRegressionMap(clusters []string) (map[string]cluster
 	return regressionMap, nil
 }
 
-func (rf ringFactory) clientRing(clientCfg config.ClientConfig) (shardsRing, error) {
+func (rf ringFactory) clientRing(clientCfg shardingconfig.ClientConfig) (shardsRing, error) {
 	clientClusters := rf.getClientClusters(clientCfg)
 
 	shardClusterMap, err := rf.makeClusterMap(clientClusters)

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -17,13 +17,13 @@ import (
 type cluster struct {
 	http.RoundTripper
 	weight   int
-	backends []config.YAMLURL
+	backends []config.YAMLUrl
 	name     string
 }
 
 func newMultiBackendCluster(transp http.RoundTripper,
 	multiResponseHandler transport.MultipleResponsesHandler,
-	clusterConf config.ClusterConfig, name string, maintainedBackends []config.YAMLURL) cluster {
+	clusterConf config.ClusterConfig, name string, maintainedBackends []config.YAMLUrl) cluster {
 	backends := make([]url.URL, len(clusterConf.Backends))
 
 	for i, backend := range clusterConf.Backends {
@@ -73,7 +73,7 @@ func (rf ringFactory) getCluster(name string) (cluster, error) {
 }
 
 func (rf ringFactory) uniqBackends(clientCfg config.ClientConfig) ([]url.URL, error) {
-	allBackendsSet := make(map[config.YAMLURL]bool)
+	allBackendsSet := make(map[config.YAMLUrl]bool)
 	log.Debugf("client %v", clientCfg.Clusters)
 	for _, name := range clientCfg.Clusters {
 		log.Debugf("cluster %s", name)

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -11,7 +11,6 @@ import (
 	"github.com/allegro/akubra/log"
 	shardingconfig "github.com/allegro/akubra/sharding/config"
 	"github.com/allegro/akubra/transport"
-	units "github.com/docker/go-units"
 	"github.com/serialx/hashring"
 )
 
@@ -197,10 +196,6 @@ func NewHandler(conf config.Config) (http.Handler, error) {
 	conf.Mainlog.Printf("Ring sharded into %d partitions", len(ring.shardClusterMap))
 
 	roundTripper := httphandler.DecorateRoundTripper(conf, ring)
-	bodyMaxSize, err := units.FromHumanSize(conf.BodyMaxSize)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to parse BodyMaxSize: %s" + err.Error())
-	}
 
-	return httphandler.NewHandlerWithRoundTripper(roundTripper, bodyMaxSize)
+	return httphandler.NewHandlerWithRoundTripper(roundTripper, conf.BodyMaxSize.SizeInBytes)
 }

--- a/sharding/sharding_test.go
+++ b/sharding/sharding_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mkDummySrvsWithfun(count int, t *testing.T, handlerfunc func(w http.ResponseWriter, r *http.Request)) []config.YAMLURL {
-	urls := make([]config.YAMLURL, 0, count)
+func mkDummySrvsWithfun(count int, t *testing.T, handlerfunc func(w http.ResponseWriter, r *http.Request)) []config.YAMLUrl {
+	urls := make([]config.YAMLUrl, 0, count)
 	dummySrvs := make([]*httptest.Server, 0, count)
 	for i := 0; i < count; i++ {
 		handlerfun := http.HandlerFunc(handlerfunc)
@@ -31,12 +31,12 @@ func mkDummySrvsWithfun(count int, t *testing.T, handlerfunc func(w http.Respons
 		if err != nil {
 			t.Error(err)
 		}
-		urls = append(urls, config.YAMLURL{URL: urlN})
+		urls = append(urls, config.YAMLUrl{URL: urlN})
 	}
 	return urls
 }
 
-func mkDummySrvs(count int, stream []byte, t *testing.T) []config.YAMLURL {
+func mkDummySrvs(count int, stream []byte, t *testing.T) []config.YAMLUrl {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write(stream)
 		assert.Nil(t, err)
@@ -50,7 +50,7 @@ var defaultClusterConfig = config.ClusterConfig{
 	Options: map[string]string{},
 }
 
-func configure(backends []config.YAMLURL) config.Config {
+func configure(backends []config.YAMLUrl) config.Config {
 
 	methodsSlice := []string{"PUT", "GET", "DELETE"}
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/allegro/akubra/config"
 	"github.com/allegro/akubra/log"
 	"github.com/allegro/akubra/metrics"
+	shardingconfig "github.com/allegro/akubra/sharding/config"
 )
 
 // ReqResErrTuple is intermediate structure for internal use of
@@ -278,7 +278,7 @@ func (mt *MultiTransport) RoundTrip(req *http.Request) (resp *http.Response, err
 func NewMultiTransport(roundTripper http.RoundTripper,
 	backends []url.URL,
 	responsesHandler MultipleResponsesHandler,
-	maintainedBackends []config.YAMLUrl) *MultiTransport {
+	maintainedBackends []shardingconfig.YAMLUrl) *MultiTransport {
 	if responsesHandler == nil {
 		responsesHandler = DefaultHandleResponses
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -278,7 +278,7 @@ func (mt *MultiTransport) RoundTrip(req *http.Request) (resp *http.Response, err
 func NewMultiTransport(roundTripper http.RoundTripper,
 	backends []url.URL,
 	responsesHandler MultipleResponsesHandler,
-	maintainedBackends []config.YAMLURL) *MultiTransport {
+	maintainedBackends []config.YAMLUrl) *MultiTransport {
 	if responsesHandler == nil {
 		responsesHandler = DefaultHandleResponses
 	}


### PR DESCRIPTION
It's important in CI and release processes for HA. One characters/type bug or wrong data structure in YAML field it's generating possible problem with akubra starting.
We would like to verifying config file without starting application with --test|-t parameter. E.g.
```
./akubra -c test.cfg.yaml -t
2017/03/22 14:12:58 Akubra (development version)
2017/03/22 14:12:58 Configuration checked - OK.

------

./akubra -c test.cfg.yaml -t
FATAL [0000] [ ERROR ] Problem with parsing config file: 'test.cfg.yaml' - err: sync log method should be one from: GET, POST, DELETE, HEAD, OPTIONS - got "PUTs" !
```
When exitcode is 0 it's information about valid YAML configuration.
When we have non-zero exitcode on STDOUT/STDERR we can see error message with reason description.