### PR TITLE
Validate config technical HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Configuration is read from a YAML configuration file with the following fields:
 ```yaml
 # Listen interface and port e.g. "127.0.0.1:9090", ":80"
 Listen: ":8080"
+TechnicalEndpointListen: ":8071"
 # Additional not AWS S3 specific headers proxy will add to original request
 AdditionalResponseHeaders:
     'Access-Control-Allow-Origin': "*"

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 type YamlConfig struct {
 	// Listen interface and port e.g. "0.0.0.0:8000", "127.0.0.1:9090", ":80"
 	Listen string `yaml:"Listen,omitempty" validate:"regexp=^(([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)?[:][0-9]+)$"`
+	TechnicalEndpointListen string `yaml:"TechnicalEndpointListen,omitempty" validate:"regexp=^(([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)?[:][0-9]+)$"`
 	// List of backend URI's e.g. "http://s3.mydatacenter.org"
 	Backends []shardingconfig.YAMLUrl `yaml:"Backends,omitempty,flow"`
 	// Maximum accepted body size

--- a/config/config.go
+++ b/config/config.go
@@ -185,51 +185,51 @@ func ValidateConf(conf YamlConfig, enableLogicalValidator bool) (bool, map[strin
 }
 
 // ValidateConfigurationHTTPHandler is used in technical HTTP endpoint for config file validation
-func ValidateConfigurationHTTPHandler(response http.ResponseWriter, request *http.Request) {
-	if request.Method != http.MethodPost {
-		response.WriteHeader(http.StatusMethodNotAllowed)
+func ValidateConfigurationHTTPHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
 
-	validationResult := RequestHeaderContentLengthValidator(*request, TechnicalEndpointBodyMaxSize)
+	validationResult := RequestHeaderContentLengthValidator(*r, TechnicalEndpointBodyMaxSize)
 	if validationResult > 0 {
-		response.WriteHeader(validationResult)
+		w.WriteHeader(validationResult)
 		return
 	}
 
-	validationResult = RequestHeaderContentTypeValidator(*request, TechnicalEndpointHeaderContentType)
+	validationResult = RequestHeaderContentTypeValidator(*r, TechnicalEndpointHeaderContentType)
 	if validationResult > 0 {
-		response.WriteHeader(validationResult)
+		w.WriteHeader(validationResult)
 		return
 	}
 
-	response.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	body, err := ioutil.ReadAll(request.Body)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		response.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(response, fmt.Sprintf("Request Body Read Error: %s\n", err))
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, fmt.Sprintf("Request Body Read Error: %s\n", err))
 		return
 	}
 
 	var yamlConfig YamlConfig
 	err = yaml.Unmarshal(body, &yamlConfig)
 	if err != nil {
-		response.WriteHeader(http.StatusBadRequest)
-		io.WriteString(response, fmt.Sprintf("YAML Unmarshal Error: %s", err))
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, fmt.Sprintf("YAML Unmarshal Error: %s", err))
 		return
 	}
-	defer request.Body.Close()
+	defer r.Body.Close()
 
 	valid, errs := ValidateConf(yamlConfig, true)
 	if !valid {
 		log.Println("YAML validation - by technical endpoint - errors:", errs)
-		response.WriteHeader(http.StatusBadRequest)
-		io.WriteString(response, fmt.Sprintf("%s", errs))
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, fmt.Sprintf("%s", errs))
 		return
 	}
 	log.Println("Configuration checked (by technical endpoint) - OK.")
-	fmt.Fprintf(response, "Configuration checked - OK.")
+	fmt.Fprintf(w, "Configuration checked - OK.")
 
-	response.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusOK)
 	return
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"fmt"
+
 	"github.com/allegro/akubra/log"
 	logconfig "github.com/allegro/akubra/log/config"
 	"github.com/allegro/akubra/metrics"
@@ -177,7 +178,8 @@ func ValidateConf(conf YamlConfig, enableLogicalValidator bool) (bool, map[strin
 	return valid, validationErrors
 }
 
-func ValidateConfigurationHttpHandler(w http.ResponseWriter, req *http.Request) {
+// ValidateConfigurationHTTPHandler is used in technical HTTP endpoint for config file validation
+func ValidateConfigurationHTTPHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		w.WriteHeader(http.StatusNotAcceptable)
 		return

--- a/config/validator.go
+++ b/config/validator.go
@@ -78,6 +78,20 @@ func (c *YamlConfig) ClientClustersEntryLogicalValidator(valid *bool, validation
 	*validationErrors = mergeErrors(*validationErrors, errorsList)
 }
 
+// ListenPortsLogicalValidator make sure that listen port and technical listen port are not equal
+func (c *YamlConfig) ListenPortsLogicalValidator(valid *bool, validationErrors *map[string][]error) {
+	errorsList := make(map[string][]error)
+	listenParts := strings.Split(c.Listen, ":")
+	listenTechnicalParts := strings.Split(c.TechnicalEndpointListen, ":")
+
+	if listenParts[0] == listenTechnicalParts[0] && listenParts[1] == listenTechnicalParts[1] {
+		*valid = false
+		errorDetail := []error{errors.New("Listen and TechnicalEndpointListen has the same port")}
+		errorsList["ListenPortsLogicalValidator"] = errorDetail
+	}
+	*validationErrors = mergeErrors(*validationErrors, errorsList)
+}
+
 func mergeErrors(maps ...map[string][]error) (output map[string][]error) {
 	size := len(maps)
 	if size == 0 {

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -64,7 +64,7 @@ func TestShouldPassClientClustersEntryLogicalValidator(t *testing.T) {
 	validationErrors := make(map[string][]error)
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{existingClusterName})
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", ":81", "client1", []string{existingClusterName})
 	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
 
 	assert.Len(t, validationErrors, 0, "Should not be errors")
@@ -77,7 +77,7 @@ func TestShouldNotPassClientClustersEntryLogicalValidatorWhenClusterDoesNotExist
 	validationErrors := make(map[string][]error)
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{notExistingClusterName})
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", ":81", "client1", []string{notExistingClusterName})
 	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
 
 	assert.Len(t, validationErrors, 1, "Should be one error")
@@ -89,8 +89,37 @@ func TestShouldNotPassClientClustersEntryLogicalValidatorWhenEmptyClustersDefini
 	validationErrors := make(map[string][]error)
 	var size shardingconfig.HumanSizeUnits
 	size.SizeInBytes = 2048
-	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", "client1", []string{})
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", ":80", ":81", "client1", []string{})
 	yamlConfig.ClientClustersEntryLogicalValidator(&valid, &validationErrors)
+
+	assert.Len(t, validationErrors, 1, "Should be one error")
+	assert.False(t, valid, "Should be false")
+}
+
+func TestShouldPassListenPortsLogicalValidator(t *testing.T) {
+	listen := ":8080"
+	listenTechnicalEndpoint := ":8081"
+	existingClusterName := "cluster1test"
+	valid := true
+	validationErrors := make(map[string][]error)
+	var size shardingconfig.HumanSizeUnits
+	size.SizeInBytes = 2048
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", listen, listenTechnicalEndpoint, "client1", []string{existingClusterName})
+	yamlConfig.ListenPortsLogicalValidator(&valid, &validationErrors)
+
+	assert.Len(t, validationErrors, 0, "Should not be errors")
+	assert.True(t, valid, "Should be true")
+}
+func TestShouldNotPassListenPortsLogicalValidatorWhenPortsAreEqual(t *testing.T) {
+	listen := "127.0.0.1:8080"
+	listenTechnicalEndpoint := listen
+	existingClusterName := "cluster1test"
+	valid := true
+	validationErrors := make(map[string][]error)
+	var size shardingconfig.HumanSizeUnits
+	size.SizeInBytes = 2048
+	yamlConfig := PrepareYamlConfig(size, 31, 45, "127.0.0.1:81", listen, listenTechnicalEndpoint, "client1", []string{existingClusterName})
+	yamlConfig.ListenPortsLogicalValidator(&valid, &validationErrors)
 
 	assert.Len(t, validationErrors, 1, "Should be one error")
 	assert.False(t, valid, "Should be false")

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -3,8 +3,12 @@ package config
 import (
 	"testing"
 
+	"net/http"
+	"net/http/httptest"
+
 	shardingconfig "github.com/allegro/akubra/sharding/config"
 	"github.com/go-validator/validator"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -110,6 +114,7 @@ func TestShouldPassListenPortsLogicalValidator(t *testing.T) {
 	assert.Len(t, validationErrors, 0, "Should not be errors")
 	assert.True(t, valid, "Should be true")
 }
+
 func TestShouldNotPassListenPortsLogicalValidatorWhenPortsAreEqual(t *testing.T) {
 	listen := "127.0.0.1:8080"
 	listenTechnicalEndpoint := listen
@@ -123,4 +128,52 @@ func TestShouldNotPassListenPortsLogicalValidatorWhenPortsAreEqual(t *testing.T)
 
 	assert.Len(t, validationErrors, 1, "Should be one error")
 	assert.False(t, valid, "Should be false")
+}
+
+func TestShouldPassHeaderContentLengthValidator(t *testing.T) {
+	var bodySizeLimit int64 = 128
+	request := httptest.NewRequest("POST", "http://somepath", nil)
+	request.Header.Set("Content-Length", "128")
+	result := RequestHeaderContentLengthValidator(*request, bodySizeLimit)
+	assert.Equal(t, 0, result)
+}
+
+func TestShouldNotPassHeaderContentLengthValidatorAndReturnEntityTooLargeCode(t *testing.T) {
+	var bodySizeLimit int64 = 1024
+	request := httptest.NewRequest("POST", "http://somepath", nil)
+	request.Header.Set("Content-Length", "1025")
+	result := RequestHeaderContentLengthValidator(*request, bodySizeLimit)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, result)
+}
+
+func TestShouldNotPassHeaderContentLengthValidatorAndReturnBadRequestOnUnparsableContentLengthHeader(t *testing.T) {
+	var bodySizeLimit int64 = 64
+	request := httptest.NewRequest("POST", "http://somepath", nil)
+	request.Header.Set("Content-Length", "strange-content-header")
+	result := RequestHeaderContentLengthValidator(*request, bodySizeLimit)
+	assert.Equal(t, http.StatusBadRequest, result)
+}
+
+func TestShouldPassRequestHeaderContentTypeValidator(t *testing.T) {
+	requiredContentType := "application/yaml"
+	request := httptest.NewRequest("POST", "http://somepath", nil)
+	request.Header.Set("Content-Type", "application/yaml")
+	result := RequestHeaderContentTypeValidator(*request, requiredContentType)
+	assert.Equal(t, 0, result)
+}
+
+func TestShouldNotPassRequestHeaderContentTypeValidatorWhenContentTypeIsEmpty(t *testing.T) {
+	requiredContentType := "application/yaml"
+	request := httptest.NewRequest("POST", "http://somepath", nil)
+	request.Header.Set("Content-Type", "")
+	result := RequestHeaderContentTypeValidator(*request, requiredContentType)
+	assert.Equal(t, http.StatusBadRequest, result)
+}
+
+func TestShouldNotPassRequestHeaderContentTypeValidatorWhenContentTypeIsUnsupported(t *testing.T) {
+	requiredContentType := "application/yaml"
+	request := httptest.NewRequest("POST", "http://somepath", nil)
+	request.Header.Set("Content-Type", "application/json")
+	result := RequestHeaderContentTypeValidator(*request, requiredContentType)
+	assert.Equal(t, http.StatusUnsupportedMediaType, result)
 }

--- a/httphandler/httphandler.go
+++ b/httphandler/httphandler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/allegro/akubra/config"
@@ -74,19 +73,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *Handler) validateIncomingRequest(req *http.Request) int {
-	var contentLength int64
-	contentLengthHeader := req.Header.Get("Content-Length")
-	if contentLengthHeader != "" {
-		var err error
-		contentLength, err = strconv.ParseInt(contentLengthHeader, 10, 64)
-		if err != nil {
-			return http.StatusBadRequest
-		}
-	}
-	if contentLength > h.bodyMaxSize || req.ContentLength > h.bodyMaxSize {
-		return http.StatusRequestEntityTooLarge
-	}
-	return 0
+	return config.RequestHeaderContentLengthValidator(*req, h.bodyMaxSize)
 }
 
 // ConfigureHTTPTransport returns http.Transport with customized dialer,

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func (s *service) startTechnicalEndpoint(conf config.Config) {
 	serveMuxHandler := http.NewServeMux()
 	serveMuxHandler.HandleFunc(
 		"/validate/configuration",
-		config.ValidateConfigurationHttpHandler,
+		config.ValidateConfigurationHTTPHandler,
 	)
 	graceful.Run(
 		conf.TechnicalEndpointListen,

--- a/main.go
+++ b/main.go
@@ -19,6 +19,9 @@ import (
 // YamlValidationErrorExitCode for problems with YAML config validation
 const YamlValidationErrorExitCode = 20
 
+// TechnicalEndpointGeneralTimeout for /configuration/validate endpoint
+const TechnicalEndpointGeneralTimeout = 5 * time.Second
+
 type service struct {
 	conf config.Config
 }
@@ -118,11 +121,10 @@ func (s *service) startTechnicalEndpoint(conf config.Config) {
 				Addr:           conf.TechnicalEndpointListen,
 				Handler:        serveMuxHandler,
 				MaxHeaderBytes: 512,
-				WriteTimeout:   5 * time.Second,
-				ReadTimeout:    10 * time.Second,
+				WriteTimeout:   TechnicalEndpointGeneralTimeout,
+				ReadTimeout:    TechnicalEndpointGeneralTimeout,
 			},
-			Timeout:      10 * time.Second,
-			ListenLimit:  10,
+			Timeout:      TechnicalEndpointGeneralTimeout,
 			TCPKeepAlive: 1 * time.Minute,
 			Logger:       graceful.DefaultLogger(),
 		}


### PR DESCRIPTION
For CI proccess we need technical/validation HTTP endpoint for validation Akubra Yaml configuration.
When we POST akubra config file:
```
curl -vv -X POST -H "Content-Type: application/yaml" --data-binary @test.cfg.yaml http://127.0.0.1:8071/validate/configuration
```
W got possible responses:
- HTTP 400 and info in body about validation errors
- HTTP 200 when pass validation