### PR TITLE
GitHub tag badge in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Version Widget]][Version] [![Build Status Widget]][Build Status] [![GoDoc Widget]][GoDoc]
 
 [Version]: https://github.com/allegro/akubra/releases/latest
-[Version Widget]: https://img.shields.io/github/release/allegro/akubra.svg
+[Version Widget]: https://img.shields.io/github/tag/allegro/akubra.svg
 [Build Status]: https://travis-ci.org/allegro/akubra
 [Build Status Widget]: https://travis-ci.org/allegro/akubra.svg?branch=master
 [GoDoc]: https://godoc.org/github.com/allegro/akubra


### PR DESCRIPTION
This project does not have GitHub releases, so GitHub release badge does not work (first badge in Readme). We can use tag badge instead.