### PR TITLE
Include all signed headers when not signing

### DIFF
--- a/external/miniotweak/s3signer/request-signature-streaming.go
+++ b/external/miniotweak/s3signer/request-signature-streaming.go
@@ -132,7 +132,7 @@ func buildChunkSignature(chunkData []byte, reqTime time.Time, region, service,
 // getSeedSignature - returns the seed signature for a given request.
 func (s *StreamingReader) setSeedSignature(req *http.Request, ignoredHeaders map[string]bool) {
 	// Get canonical request
-	canonicalRequest := getCanonicalRequest(req, ignoredHeaders)
+	canonicalRequest := getCanonicalRequest(req, ignoredHeaders, true)
 
 	// Get string to sign from canonical request.
 	stringToSign := getStringToSignV4(s.reqTime, s.region, s.service, canonicalRequest)
@@ -197,7 +197,7 @@ func (s *StreamingReader) setStreamingAuthHeader(req *http.Request, ignoredHeade
 	credential := GetCredential(s.accessKeyID, s.region, s.service, s.reqTime)
 	authParts := []string{
 		signV4Algorithm + " Credential=" + credential,
-		"SignedHeaders=" + getSignedHeaders(req, ignoredHeaders),
+		"SignedHeaders=" + getSignedHeaders(req, ignoredHeaders, true),
 		"Signature=" + s.seedSignature,
 	}
 

--- a/external/miniotweak/s3signer/request-signature-v4_test.go
+++ b/external/miniotweak/s3signer/request-signature-v4_test.go
@@ -28,7 +28,7 @@ func TestRequestHost(t *testing.T) {
 	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
 	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	req.Host = "myhost"
-	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders)
+	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders, true)
 
 	if !strings.Contains(canonicalHeaders, "host:"+req.Host) {
 		t.Errorf("canonical host header invalid")
@@ -41,7 +41,7 @@ func TestIncludeXAMZHeaders(t *testing.T) {
 	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
 	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	req.Host = "myhost"
-	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders)
+	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders, true)
 
 	if !strings.Contains(canonicalHeaders, "x-amz-meta-other-header") {
 		t.Errorf("x-amz-meta-other-header should be in canonical headers")
@@ -52,10 +52,23 @@ func TestExcludeNoNonAMZXHeaders(t *testing.T) {
 	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
 	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	req.Host = "myhost"
-	canonicalHeaders,_ := getHeadersToSign(req, v4IgnoredHeaders)
+	canonicalHeaders,_ := getHeadersToSign(req, v4IgnoredHeaders, true)
 
 	if contains(canonicalHeaders, "x-non-amz-header") {
 		t.Errorf("X-non-amz-header should not be found")
+	}
+}
+
+
+
+func TestNotExcludeNoNonAMZXHeadersWhenNotSigning(t *testing.T) {
+	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
+	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
+	req.Host = "myhost"
+	canonicalHeaders,_ := getHeadersToSign(req, v4IgnoredHeaders, false)
+
+	if !contains(canonicalHeaders, "x-non-amz-header") {
+		t.Errorf("X-non-amz-header should be found")
 	}
 }
 func contains(s []string, e string) bool {


### PR DESCRIPTION
Non-amz headers were ignored when verifying the signature even though they were included in the `Signed headers` part of the authorization string