### PR TITLE
Fixing a simple misspelling (explicilty and requried)

### DIFF
--- a/internal/akubra/config/validator_test.go
+++ b/internal/akubra/config/validator_test.go
@@ -563,14 +563,14 @@ func TestCredentialsStoresValidation(t *testing.T) {
 			crdStoreConig.CredentialsStoreMap{
 				"store1": {Default: false, Type: "Vault"},
 			},
-			[]error{errors.New("you have to define a default CredentialsStore when Storages don't have CredentialsStores specified explicilty")}},
+			[]error{errors.New("you have to define a default CredentialsStore when Storages don't have CredentialsStores specified explicitly")}},
 		{"Should fail when a required property is missing in CredentialStoresConfig",
 			crdStoreConig.CredentialsStoreMap{
 				"store1": {Default: true, Type: "Vault", Properties: map[string]string{
 					"Timeout": "300", "MaxRetries": "3", "PathPrefix": "/secret",
 				}},
 			},
-			[]error{errors.New("CredentialsStore 'store1' is missing requried property 'Endpoint'")}},
+			[]error{errors.New("CredentialsStore 'store1' is missing required property 'Endpoint'")}},
 	} {
 
 		var size httphandlerconfig.HumanSizeUnits


### PR DESCRIPTION
This PR does not have changes that affect logics, but only typos.

1. "explicilty" instead of "explicitly"
2. "requried" iinstead of "required"
